### PR TITLE
feat: implement quick start onboarding page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,7 +1530,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1541,7 +1540,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1552,7 +1550,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -1577,7 +1574,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1778,7 +1774,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -2096,7 +2091,6 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2671,7 +2665,6 @@
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -3123,7 +3116,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3300,7 +3292,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3313,7 +3304,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3876,7 +3866,6 @@
       "integrity": "sha512-qO3aKv3HoQC8QKiNSTuUM1l9o/XX3+c+VTgLHbJWHZGeTPVAg2XwazI9UWzoxjIJCGCV2zU60uqMzjeLZuULqA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import FitnessWorld from "./pages/FitnessWorld";
 import StudyWorld from "./pages/StudyWorld";
 import NotFound from "./pages/NotFound";
 import SocialWorld from "./pages/SocialWorld";
+import QuickStart from "./pages/QuickStart";
 
 const queryClient = new QueryClient();
 
@@ -15,6 +16,7 @@ const App = () => (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Index />} />
+        <Route path="/quick-start" element={<QuickStart />} />
         <Route path="/worlds" element={<Worlds />} />
         <Route path="/worlds/fitness" element={<FitnessWorld />} />
         <Route path="/worlds/study" element={<StudyWorld />} />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,12 +24,18 @@ const Index = () => {
         </div>
 
         {/* CTA */}
-        <div className="animate-fade-up animate-fade-up-delay-2">
+        <div className="animate-fade-up animate-fade-up-delay-2 flex flex-col sm:flex-row items-center justify-center gap-4">
+          <button
+            onClick={() => navigate("/quick-start")}
+            className="w-full sm:w-auto px-8 py-3 bg-primary text-primary-foreground font-heading font-semibold text-sm tracking-wide border-none cursor-pointer transition-all duration-200 hover:translate-y-[-2px] hover:shadow-[0_4px_0_0_hsl(var(--primary)/0.4)] active:translate-y-0 active:shadow-none"
+          >
+            Quick Start
+          </button>
           <button
             onClick={() => navigate("/worlds")}
-            className="px-8 py-3 bg-primary text-primary-foreground font-heading font-semibold text-sm tracking-wide border-none cursor-pointer transition-all duration-200 hover:translate-y-[-2px] hover:shadow-[0_4px_0_0_hsl(var(--primary)/0.4)] active:translate-y-0 active:shadow-none"
+            className="w-full sm:w-auto px-8 py-3 bg-transparent text-primary font-heading font-semibold text-sm tracking-wide border border-primary cursor-pointer transition-all duration-200 hover:bg-primary/5 hover:translate-y-[-2px] active:translate-y-0"
           >
-            → Explore Side Quests
+            Explore Side Quests
           </button>
         </div>
 

--- a/src/pages/QuickStart.tsx
+++ b/src/pages/QuickStart.tsx
@@ -1,0 +1,111 @@
+import { useNavigate } from "react-router-dom";
+import { Globe, Target, CheckCircle, ArrowRight } from "lucide-react";
+
+const QuickStart = () => {
+  const navigate = useNavigate();
+
+  const steps = [
+    {
+      icon: <Globe className="w-8 h-8 text-primary" />,
+      title: "Choose a World",
+      description: <>Select a <span className="text-primary font-bold">domain</span> like Fitness, Study, or Social.</>
+    },
+    {
+      icon: <Target className="w-8 h-8 text-primary" />,
+      title: "Pick a Quest",
+      description: <>Choose <span className="text-primary font-bold">small tasks</span> that fit your daily schedule.</>
+    },
+    {
+      icon: <CheckCircle className="w-8 h-8 text-primary" />,
+      title: "Track Progress",
+      description: <>Complete quests to <span className="text-primary font-bold">build consistency</span> over time.</>
+    }
+  ];
+
+  const featuredQuests = [
+    { id: "walk", title: "Go for a walk", world: "Fitness", path: "/worlds/fitness", emoji: "🏋️" },
+    { id: "read", title: "Read for 20 minutes", world: "Study", path: "/worlds/study", emoji: "📚" }
+  ];
+
+  return (
+    <div className="min-h-screen grid-bg">
+      {/* Header */}
+      <header className="border-b border-border px-6 py-4 flex items-center justify-between">
+        <button
+          onClick={() => navigate("/")}
+          className="font-heading font-bold text-foreground text-lg bg-transparent border-none cursor-pointer hover:text-primary transition-colors"
+        >
+          SQ
+        </button>
+        <span className="text-muted-foreground text-xs font-mono">worlds://quick-start</span>
+      </header>
+
+      {/* Main Content */}
+      <main className="max-w-4xl mx-auto px-6 py-12">
+        <div className="space-y-16 animate-fade-up">
+
+          {/* Header section */}
+          <div className="text-center space-y-4">
+            <h1 className="text-4xl md:text-5xl font-heading font-bold text-foreground tracking-tight">
+              Getting Started
+            </h1>
+            <p className="text-muted-foreground text-base md:text-lg font-mono max-w-2xl mx-auto">
+              Welcome to SideQuest Worlds. Here's how to begin your journey toward consistent growth.
+            </p>
+          </div>
+
+          {/* Steps section */}
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {steps.map((step, index) => (
+              <div key={index} className="panel-hover p-8 space-y-4">
+                <div className="flex justify-center md:justify-start">{step.icon}</div>
+                <h3 className="text-xl font-heading font-semibold text-foreground">{step.title}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">{step.description}</p>
+              </div>
+            ))}
+          </div>
+
+          {/* Suggested Quests */}
+          <div className="space-y-8">
+            <div className="text-center md:text-left border-l-2 border-primary pl-6">
+              <h2 className="text-2xl font-heading font-bold text-foreground text-left">Featured Quests</h2>
+              <p className="text-sm text-muted-foreground font-mono text-left mt-1">Jump directly into one of these starter activities.</p>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              {featuredQuests.map((quest) => (
+                <div key={quest.id} className="panel-hover p-6 flex flex-col justify-between group">
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-3xl">{quest.emoji}</span>
+                      <span className="text-[10px] font-mono uppercase tracking-widest text-muted-foreground">{quest.world} World</span>
+                    </div>
+                    <h3 className="text-xl font-heading font-bold text-foreground">{quest.title}</h3>
+                  </div>
+                  <button
+                    onClick={() => navigate(quest.path)}
+                    className="mt-8 group-hover:text-primary transition-colors flex items-center gap-2 text-sm font-mono font-bold uppercase tracking-wider"
+                  >
+                    Start this quest <ArrowRight className="w-4 h-4" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* CTA */}
+          <div className="pt-12 text-center">
+            <button
+              onClick={() => navigate("/worlds")}
+              className="px-10 py-4 bg-primary text-primary-foreground font-heading font-bold text-sm tracking-widest uppercase cursor-pointer transition-all hover:translate-y-[-2px]"
+            >
+              Explore All Worlds
+            </button>
+          </div>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default QuickStart;


### PR DESCRIPTION
## Related Issue
Closes #12

---

## Description
Introduces a **"Quick Start"** page to guide new users through the core app flow (Choose → Pick → Track).

Also standardizes the layout to ensure:
- Full-width header
- Consistent design across the platform

---

## File Changes

### `src/pages/QuickStart.tsx`
- Created onboarding UI with a 3-step guide and featured quests  
- Fixed layout by nesting the header inside `grid-bg` for edge-to-edge borders  

### `src/App.tsx`
- Registered the `/quick-start` route  

### `src/pages/Index.tsx`
- Added a **"Quick Start"** CTA button to the hero section  

---

## Visuals

https://github.com/user-attachments/assets/9b7ca74b-0e5e-4ac9-81ee-e5ca9dd41999

---

## Conclusion

Please let me know if any changes are required. If everything looks good, I’d appreciate a merge!