### PR TITLE
feat: add custom favicon and ensure it loads correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,13 +2,20 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <title>SideQuest Worlds</title>
-    <meta name="description" content="Explore different worlds and complete small quests in a modular system." />
+    <meta
+      name="description"
+      content="Explore different worlds and complete small quests in a modular system."
+    />
 
     <meta property="og:title" content="SideQuest Worlds" />
-    <meta property="og:description" content="A modular quest-based web system." />
+    <meta
+      property="og:description"
+      content="A modular quest-based web system."
+    />
     <meta property="og:type" content="website" />
   </head>
 

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- Dark background -->
+  <rect width="64" height="64" fill="#111111" rx="0"/>
+  <!-- Yellow border -->
+  <rect x="6" y="6" width="52" height="52" fill="none" 
+        stroke="#EAB308" stroke-width="1" rx="0"/>
+  <!-- SQ text -->
+  <text x="32" y="34" 
+        text-anchor="middle" 
+        dominant-baseline="middle"
+        font-family="monospace" 
+        font-weight="bold" 
+        font-size="18" 
+        fill="#EAB308">SQ</text>
+</svg>


### PR DESCRIPTION
## What does this PR do?
This PR adds a custom favicon to the SideQuest Worlds web app that matches the existing SQ brand logo used on the homepage.
Previously the browser tab showed no icon, this PR fixes that by adding a custom SVG favicon with the SQ logo design.

Fixes #1 

## Changes Made
- Created `public/favicon.svg` with the SQ logo design
- Linked the favicon in `index.html` inside the `<head>` section
 
## Screenshots
<img width="557" height="44" alt="Screenshot 2026-04-06 195445" src="https://github.com/user-attachments/assets/dad58ae7-cef1-44ba-a43d-970310040ad8" />