### PR TITLE
feat: add Detox World for screen time and focus quests

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import SocialWorld from "./pages/SocialWorld";
 import CreativeWorld from "./pages/CreativeWorld";
 import QuickStart from "./pages/QuickStart";
 import RandomQuest from "./pages/RandomQuest";
+import DetoxWorld from "./pages/DetoxWorld";
 
 const queryClient = new QueryClient();
 
@@ -24,6 +25,7 @@ const App = () => (
         <Route path="/worlds/study" element={<StudyWorld />} />
         <Route path="/worlds/social" element={<SocialWorld />} />
         <Route path="/worlds/creative" element={<CreativeWorld />} />
+        <Route path="/worlds/detox" element={<DetoxWorld />} />
         <Route path="/random" element={<RandomQuest />} />
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/src/data/detoxQuests.ts
+++ b/src/data/detoxQuests.ts
@@ -1,0 +1,17 @@
+import type { Quest } from "./fitnessQuests";
+
+export const detoxQuests: Quest[] = [
+  { id: "no-phone-10", title: "No phone for 10 minutes" },
+  { id: "disable-notifs", title: "Disable all notifications for 1 hour" },
+  { id: "grayscale", title: "Switch phone to grayscale mode" },
+  { id: "no-social", title: "Stay off social media for 2 hours" },
+  { id: "phone-box", title: "Put your phone in another room for 30 minutes" },
+  { id: "no-scroll-morning", title: "Don't check your phone for first 30 min after waking" },
+  { id: "app-limits", title: "Set a 15-min daily limit on your most-used app" },
+  { id: "focus-session", title: "Do a 25-min deep work session, phone face-down" },
+  { id: "delete-app", title: "Delete one app you mindlessly open" },
+  { id: "no-screen-meal", title: "Eat a meal without any screen" },
+  { id: "screen-curfew", title: "No screens 30 minutes before bed" },
+  { id: "airplane-mode", title: "Turn on airplane mode for 20 minutes" },
+  { id: "check-screentime", title: "Check your screen time report and set a goal" },
+];

--- a/src/pages/DetoxWorld.tsx
+++ b/src/pages/DetoxWorld.tsx
@@ -1,0 +1,11 @@
+import WorldLayout from "@/components/WorldLayout";
+import QuestList from "@/components/QuestList";
+import { detoxQuests } from "@/data/detoxQuests";
+
+const DetoxWorld = () => (
+  <WorldLayout worldName="Detox World">
+    <QuestList worldId="detox" worldName="Detox World" worldEmoji="📵" quests={detoxQuests} />
+  </WorldLayout>
+);
+
+export default DetoxWorld;

--- a/src/pages/RandomQuest.tsx
+++ b/src/pages/RandomQuest.tsx
@@ -4,6 +4,7 @@ import { fitnessQuests } from "@/data/fitnessQuests";
 import { studyQuests } from "@/data/studyQuests";
 import { socialQuests } from "@/data/socialQuests";
 import { creativeQuests } from "@/data/creativeQuests";
+import { detoxQuests } from "@/data/detoxQuests";
 
 interface QuestWithWorld {
   id: string;
@@ -18,6 +19,7 @@ const allQuests: QuestWithWorld[] = [
   ...studyQuests.map((q) => ({ ...q, world: "Study World", emoji: "📚", worldId: "study" })),
   ...socialQuests.map((q) => ({ ...q, world: "Social World", emoji: "🤝", worldId: "social" })),
   ...creativeQuests.map((q) => ({ ...q, world: "Creative World", emoji: "🎨", worldId: "creative" })),
+  ...detoxQuests.map((q) => ({ ...q, world: "Detox World", emoji: "📵", worldId: "detox" })),
 ];
 
 const RandomQuest = () => {


### PR DESCRIPTION
## Summary
Adds a new Detox World focused on reducing screen time and improving focus.

## New Files
- `src/data/detoxQuests.ts` — 13 quests (e.g. "No phone for 10 minutes", 
  "Disable notifications for 1 hour", "No screens 30 min before bed")
- `src/pages/DetoxWorld.tsx` — world page using existing WorldLayout + QuestList

## Updated Files
- `src/App.tsx` — added DetoxWorld import + /worlds/detox route
- `src/pages/Worlds.tsx` — added 📵 Detox World card to the worlds grid
- `src/pages/RandomQuest.tsx` — detox quests now included in random pool

## How to test
1. Go to /worlds → new 📵 Detox World card appears
2. Click it → opens /worlds/detox with all 13 quests
3. Go to /random → detox quests can now be rolled
4. Complete a detox quest → progress bar updates on the Worlds page

## Notes
- No new dependencies
- Follows exact same pattern as Fitness/Study/Social/Creative worlds
- localStorage key: sidequest_detox